### PR TITLE
Fix soundmanager classnotfound crash.

### DIFF
--- a/fisherman77/paleocraft/client/PaleocraftClientProxy.java
+++ b/fisherman77/paleocraft/client/PaleocraftClientProxy.java
@@ -1,6 +1,7 @@
 package fisherman77.paleocraft.client;
 import cpw.mods.fml.client.registry.RenderingRegistry;
 import fisherman77.paleocraft.common.PaleocraftCommonProxy;
+import fisherman77.paleocraft.common.handlers.PaleocraftSoundHandler;
 import fisherman77.paleocraft.common.mobs.EntityBaryonyx;
 import fisherman77.paleocraft.common.mobs.EntityCitipati;
 import fisherman77.paleocraft.common.mobs.EntityCompy;
@@ -35,6 +36,7 @@ import fisherman77.paleocraft.common.mobs.RenderSpino;
 import fisherman77.paleocraft.common.mobs.RenderTroodon;
 import fisherman77.paleocraft.common.mobs.RenderTylo;
 import net.minecraftforge.client.MinecraftForgeClient;
+import net.minecraftforge.common.MinecraftForge;
 public class PaleocraftClientProxy extends PaleocraftCommonProxy {
         
 	public void registerRenderInformation() {
@@ -57,4 +59,7 @@ public void registerRenderers(){
 	RenderingRegistry.registerEntityRenderingHandler(EntityTylo.class, new RenderTylo(new ModelTylo(), shadowSize, 2.5F));
 }
 
+public void registerSounds() {
+	MinecraftForge.EVENT_BUS.register(new PaleocraftSoundHandler());
+}
 }

--- a/fisherman77/paleocraft/common/Paleocraft.java
+++ b/fisherman77/paleocraft/common/Paleocraft.java
@@ -140,7 +140,7 @@ public void PreLoad(FMLPreInitializationEvent e)
 /**
 * Registering Paleocraft sounds...
 **/
-MinecraftForge.EVENT_BUS.register(new PaleocraftSoundHandler());
+proxy.registerSounds();
 
 /**
  * Registering the Core Config class

--- a/fisherman77/paleocraft/common/PaleocraftCommonProxy.java
+++ b/fisherman77/paleocraft/common/PaleocraftCommonProxy.java
@@ -40,4 +40,8 @@ public void addRecipes(){ //For adding your Item's recipes
 public void registerRenderers(){
 	
 }
+
+public void registerSounds() {
+	
+}
 }


### PR DESCRIPTION
This crash occurs because registering sound handlers attempts to instantiate a soundmanager, which isn't present on the server side.
